### PR TITLE
[#77] docs: get-server-side-prop 번역

### DIFF
--- a/pages/docs/pages/api-reference/functions/get-server-side-props.mdx
+++ b/pages/docs/pages/api-reference/functions/get-server-side-props.mdx
@@ -16,7 +16,7 @@ type Repo = {
 }
 
 export const getServerSideProps = (async () => {
-  // API 외부 API에서 데이터를 가져옵니다.
+  // 외부 API에서 데이터를 가져옵니다.
   const res = await fetch('https://api.github.com/repos/vercel/next.js')
   const repo: Repo = await res.json()
   // props를 통해 페이지에 데이터를 전달합니다.
@@ -36,7 +36,7 @@ export default function Page({
 
 ```jsx filename="pages/index.js" switcher
 export async function getServerSideProps() {
-  // API 외부 API에서 데이터를 가져옵니다.
+  // 외부 API에서 데이터를 가져옵니다.
   const res = await fetch('https://api.github.com/repos/vercel/next.js')
   const repo = await res.json()
   // props를 통해 페이지에 데이터를 전달합니다.

--- a/pages/docs/pages/api-reference/functions/get-server-side-props.mdx
+++ b/pages/docs/pages/api-reference/functions/get-server-side-props.mdx
@@ -3,7 +3,7 @@ title: getServerSideProps
 description: API reference for `getServerSideProps`. Learn how to fetch data on each request with Next.js.
 ---
 
-When exporting a function called `getServerSideProps` (Server-Side Rendering) from a page, Next.js will pre-render this page on each request using the data returned by `getServerSideProps`. This is useful if you want to fetch data that changes often, and have the page update to show the most current data.
+페이지에서 `getServerSideProps` (서버 사이드 렌더링)이라는 함수를 내보내면, Next.js는 `getServerSideProps`에서 반환된 데이터를 사용해 각 요청마다 페이지를 사전 렌더링합니다. 이는 자주 변경되는 데이터를 가져오고, 페이지를 최신 데이터로 업데이트하려는 경우 유용합니다.
 
 ```tsx filename="pages/index.tsx" switcher
 import type { InferGetServerSidePropsType, GetServerSideProps } from 'next'
@@ -14,10 +14,10 @@ type Repo = {
 }
 
 export const getServerSideProps = (async () => {
-  // Fetch data from external API
+  // API 외부 API에서 데이터를 가져옵니다.
   const res = await fetch('https://api.github.com/repos/vercel/next.js')
   const repo: Repo = await res.json()
-  // Pass data to the page via props
+  // props를 통해 페이지에 데이터를 전달합니다.
   return { props: { repo } }
 }) satisfies GetServerSideProps<{ repo: Repo }>
 
@@ -34,10 +34,10 @@ export default function Page({
 
 ```jsx filename="pages/index.js" switcher
 export async function getServerSideProps() {
-  // Fetch data from external API
+  // API 외부 API에서 데이터를 가져옵니다.
   const res = await fetch('https://api.github.com/repos/vercel/next.js')
   const repo = await res.json()
-  // Pass data to the page via props
+  // props를 통해 페이지에 데이터를 전달합니다.
   return { props: { repo } }
 }
 
@@ -50,45 +50,45 @@ export default function Page({ repo }) {
 }
 ```
 
-You can import modules in top-level scope for use in `getServerSideProps`. Imports used will **not be bundled for the client-side**. This means you can write **server-side code directly in `getServerSideProps`**, including fetching data from your database.
+`getServerSideProps`에서 사용하기 위해 상위 레벨 범위에서 모듈을 가져올 수 있습니다. 사용된 임포트는 **클라이언트 사이드에 번들되지 않습니다.** 이는 데이터베이스에서 데이터를 가져오는 것을 포함해 **`getServerSideProps` 내에서 서버 사이드 코드를 직접 작성할 수 있음을 의미합니다**.
 
 ## Context parameter
 
-The `context` parameter is an object containing the following keys:
+`context` 매개변수는 다음 키를 포함하는 객체입니다:
 
 | Name            | Description                                                                                                                                                                                                           |
 | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `params`        | If this page uses a [dynamic route](/docs/pages/building-your-application/routing/dynamic-routes), `params` contains the route parameters. If the page name is `[id].js`, then `params` will look like `{ id: ... }`. |
-| `req`           | [The `HTTP` IncomingMessage object](https://nodejs.org/api/http.html#http_class_http_incomingmessage), with an additional `cookies` prop, which is an object with string keys mapping to string values of cookies.    |
-| `res`           | [The `HTTP` response object](https://nodejs.org/api/http.html#http_class_http_serverresponse).                                                                                                                        |
-| `query`         | An object representing the query string, including dynamic route parameters.                                                                                                                                          |
-| `preview`       | (Deprecated for `draftMode`) `preview` is `true` if the page is in the [Preview Mode](/docs/pages/building-your-application/configuring/preview-mode) and `false` otherwise.                                          |
-| `previewData`   | (Deprecated for `draftMode`) The [preview](/docs/pages/building-your-application/configuring/preview-mode) data set by `setPreviewData`.                                                                              |
-| `draftMode`     | `draftMode` is `true` if the page is in the [Draft Mode](/docs/pages/building-your-application/configuring/draft-mode) and `false` otherwise.                                                                         |
-| `resolvedUrl`   | A normalized version of the request `URL` that strips the `_next/data` prefix for client transitions and includes original query values.                                                                              |
-| `locale`        | Contains the active locale (if enabled).                                                                                                                                                                              |
-| `locales`       | Contains all supported locales (if enabled).                                                                                                                                                                          |
-| `defaultLocale` | Contains the configured default locale (if enabled).                                                                                                                                                                  |
+| `params`        | 이 페이지가 [동적 라우트](/docs/pages/building-your-application/routing/dynamic-routes)를 사용하는 경우, `params`에는 라우트 매개변수가 포함됩니다. 페이지 이름이 `[id].js`면, `params`는 `{ id: ... }`와 같이 표시됩니다.     |
+| `req`           | 추가적인 `cookies` prop이 있는 [The HTTP IncomingMessage 객체](https://nodejs.org/api/http.html#http_class_http_incomingmessage)이며, 이는 문자열 값을 가진 쿠키의 문자열 키를 매핑하는 객체입니다.                          |
+| `res`           | [The `HTTP` response 객체](https://nodejs.org/api/http.html#http_class_http_serverresponse)입니다.                                                                                                                     |
+| `query`         | 동적 라우트 매개변수를 포함한 쿼리 문자열을 나타내는 객체입니다.                                                                                                                                                           |
+| `preview`       | (`draftMode`로 대체 예정) 페이지가 [미리보기 모드](/docs/pages/building-your-application/configuring/preview-mode)에 있는 경우 `preview`는 `true`이고, 그렇지 않으면 `false`입니다.                                         |
+| `previewData`   | (`draftMode`로 대체 예정) `setPreviewData`에 의해 설정된 [미리보기](/docs/pages/building-your-application/configuring/preview-mode) 데이터입니다.                                                                         |
+| `draftMode`     | 페이지가 [Draft Mode](/docs/pages/building-your-application/configuring/draft-mode)에 있는 경우 `draftMode`는 `true`이고, 그렇지 않으면 `false`입니다.                                                                    |
+| `resolvedUrl`   | 클라이언트 전환을 위한 `_next/data` 접두사를 제거하고 원래 쿼리 값을 포함하는 요청 `URL`의 정규화된 버전입니다.                                                                                                              |
+| `locale`        | 활성 로케일이 포함됩니다. (활성화된 경우)                                                                                                                                                                                |
+| `locales`       | 지원되는 모든 로케일이 포함됩니다. (활성화된 경우)                                                                                                                                                                        |
+| `defaultLocale` | 설정된 기본 로케일이 포함됩니다. (활성화된 경우)                                                                                                                                                                          |
 
 ## getServerSideProps return values
 
-The `getServerSideProps` function should return an object with **any one of the following** properties:
+`getServerSideProps` 함수는 **다음 속성 중 하나를 가진 객체**를 반환해야 합니다:
 
 ### `props`
 
-The `props` object is a key-value pair, where each value is received by the page component. It should be a [serializable object](https://developer.mozilla.org/docs/Glossary/Serialization) so that any props passed, could be serialized with [`JSON.stringify`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify).
+`props` 객체는 페이지 컴포넌트가 받는 키-값 쌍입니다. 전달된 모든 props가 [`JSON.stringify`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify)로 직렬화될 수 있도록 [직렬화 가능한 객체](https://developer.mozilla.org/docs/Glossary/Serialization)여야 합니다.
 
 ```jsx
 export async function getServerSideProps(context) {
   return {
-    props: { message: `Next.js is awesome` }, // will be passed to the page component as props
+    props: { message: `Next.js is awesome` }, // 페이지 컴포넌트에 props로 전달됩니다.
   }
 }
 ```
 
 ### `notFound`
 
-The `notFound` boolean allows the page to return a `404` status and [404 Page](/docs/pages/building-your-application/routing/custom-error#404-page). With `notFound: true`, the page will return a `404` even if there was a successfully generated page before. This is meant to support use cases like user-generated content getting removed by its author.
+`notFound` 불리언 값은 페이지가 `404` 상태와 [404 Page](/docs/pages/building-your-application/routing/custom-error#404-page)를 반환하도록 합니다. `notFound: true`인 경우, 이전에 성공적으로 생성된 페이지가 있어도 페이지는 404를 반환합니다. 이는 사용자 생성 콘텐츠가 작성자에 의해 제거되는 경우와 같은 사용 사례를 지원하기 위함입니다.
 
 ```js
 export async function getServerSideProps(context) {
@@ -102,14 +102,14 @@ export async function getServerSideProps(context) {
   }
 
   return {
-    props: { data }, // will be passed to the page component as props
+    props: { data }, // 페이지 컴포넌트에 props로 전달됩니다.
   }
 }
 ```
 
 ### `redirect`
 
-The `redirect` object allows redirecting to internal and external resources. It should match the shape of `{ destination: string, permanent: boolean }`. In some rare cases, you might need to assign a custom status code for older `HTTP` clients to properly redirect. In these cases, you can use the `statusCode` property instead of the `permanent` property, but not both.
+`redirect` 객체는 내부 및 외부 리소스로 리디렉션을 허용합니다. 이는 `{ destination: string, permanent: boolean }`의 형태와 일치해야 합니다. 드물게, 이전 `HTTP` 클라이언트가 제대로 리디렉션되도록 사용자 정의 상태 코드를 할당해야 할 수도 있습니다. 이러한 경우, `permanent` 속성 대신 `statusCode` 속성을 사용할 수 있지만, 둘 다 사용할 수는 없습니다.
 
 ```js
 export async function getServerSideProps(context) {
@@ -126,15 +126,15 @@ export async function getServerSideProps(context) {
   }
 
   return {
-    props: {}, // will be passed to the page component as props
+    props: {}, // 페이지 컴포넌트에 props로 전달됩니다.
   }
 }
 ```
 
 ## Version History
 
-| Version   | Changes                                                                                                     |
-| --------- | ----------------------------------------------------------------------------------------------------------- |
-| `v13.4.0` | [App Router](/docs/app/building-your-application/data-fetching) is now stable with simplified data fetching |
-| `v10.0.0` | `locale`, `locales`, `defaultLocale`, and `notFound` options added.                                         |
-| `v9.3.0`  | `getServerSideProps` introduced.                                                                            |
+| Version   | Changes                                                                                                        |
+| --------- | -------------------------------------------------------------------------------------------------------------- |
+| `v13.4.0` | [App Router](/docs/app/building-your-application/data-fetching)가 안정화되었고, 단순화된 데이터 페칭을 지원합니다. |
+| `v10.0.0` | `locale`, `locales`, `defaultLocale`, 및 `notFound` 옵션이 추가되었습니다.                                       |
+| `v9.3.0`  | `getServerSideProps`가 도입되었습니다.                                                                           |

--- a/pages/docs/pages/building-your-application/rendering/server-side-rendering.mdx
+++ b/pages/docs/pages/building-your-application/rendering/server-side-rendering.mdx
@@ -3,34 +3,32 @@ title: Server-side Rendering (SSR)
 description: Use Server-side Rendering to render pages on each request.
 ---
 
-{/* TODO: 번역이 필요합니다. */}
-
 # Server-side Rendering (SSR)
 
-> Also referred to as "SSR" or "Dynamic Rendering".
+> "SSR" 또는 "동적 렌더링"이라고도 불립니다.
 
-If a page uses **Server-side Rendering**, the page HTML is generated on **each request**.
+페이지가 **서버 사이드 렌더링**을 사용하는 경우, 페이지 HTML은 **각 요청 시마다** 생성됩니다.
 
-To use Server-side Rendering for a page, you need to `export` an `async` function called `getServerSideProps`. This function will be called by the server on every request.
+페이지에 서버 사이드 렌더링을 사용하려면, `getServerSideProps`라는 `async` 함수를 `export` 해야 합니다. 이 함수는 매 요청마다 서버에 의해 호출됩니다.
 
-For example, suppose that your page needs to pre-render frequently updated data (fetched from an external API). You can write `getServerSideProps` which fetches this data and passes it to `Page` like below:
+예를 들어, 페이지에서 자주 업데이트되는 데이터(외부에서 가져온 데이터)를 미리 렌더링해야 한다고 가정해봅시다. 이 데이터를 가져와 아래와 같이 `Page`에 전달하는 `getServerSideProps`를 작성할 수 있습니다:
 
 ```jsx
 export default function Page({ data }) {
-  // Render data...
+  // 데이터를 렌더링합니다...
 }
 
-// This gets called on every request
+// 이 함수는 매 요청마다 호출됩니다.
 export async function getServerSideProps() {
-  // Fetch data from external API
+  // 외부 API에서 데이터를 가져옵니다.
   const res = await fetch(`https://.../data`)
   const data = await res.json()
 
-  // Pass data to the page via props
+  // props를 통해 페이지에 데이터를 전달합니다.
   return { props: { data } }
 }
 ```
 
-As you can see, `getServerSideProps` is similar to `getStaticProps`, but the difference is that `getServerSideProps` is run on every request instead of on build time.
+보시다시피, `getServerSideProps`는 `getStaticProps`와 유사하지만, 차이점은 `getServerSideProps`가 빌드 타임이 아닌 각 요청마다 실행된다는 점입니다.
 
-To learn more about how `getServerSideProps` works, check out our [Data Fetching documentation](/docs/pages/building-your-application/data-fetching/get-server-side-props).
+`getServerSideProps`가 어떻게 작동하는지 더 알고 싶다면, [Data Fetching documentation](/docs/pages/building-your-application/data-fetching/get-server-side-props)을 확인하세요.

--- a/pages/docs/pages/building-your-application/upgrading/version-13.mdx
+++ b/pages/docs/pages/building-your-application/upgrading/version-13.mdx
@@ -49,7 +49,7 @@ Next.js 12는 임시 import인 `next/future/image`로 이미지 컴포넌트에 
 
 Next.js 13부터 이러한 새로운 동작은 `next/image`의 기본 동작이 되었습니다.
 
-새로은 Image 컴포넌트로 마이그레이션하는 데 도움이 되는 두 가지 codemod가 있습니다:
+새로운 Image 컴포넌트로 마이그레이션하는 데 도움이 되는 두 가지 codemod가 있습니다:
 
 - [next-image-to-legacy-image](/docs/pages/building-your-application/upgrading/codemods#next-image-to-legacy-image): 이 codemod는 `next/image` import를 `next/legacy/image`로 안전하게 자동으로 이름을 변경하여 Next.js 12와 동일한 동작을 유지합니다. Next.js 13으로 빠르게 자동으로 업데이트를 하려면 이 codemod를 실행하는 것이 좋습니다.
 

--- a/pages/docs/pages/building-your-application/upgrading/version-13.mdx
+++ b/pages/docs/pages/building-your-application/upgrading/version-13.mdx
@@ -53,9 +53,9 @@ Next.js 13부터 이러한 새로운 동작은 `next/image`의 기본 동작이 
 
 - [next-image-to-legacy-image](/docs/pages/building-your-application/upgrading/codemods#next-image-to-legacy-image): 이 codemod는 `next/image` import를 `next/legacy/image`로 안전하게 자동으로 이름을 변경하여 Next.js 12와 동일한 동작을 유지합니다. Next.js 13으로 빠르게 자동으로 업데이트를 하려면 이 codemod를 실행하는 것이 좋습니다.
 
-- [next-image-experimental](/docs/pages/building-your-application/upgrading/codemods#next-image-experimental): 이전 codemod를 실행한 후, 이 실험적인 codemod를 선택적으로 실행하여 `next/legacy/image`를 새로운 `next/image`로 업그레이드할 수 있습니다. 이는 사용하지 않는 속성을 제거하고 인라인 스타일을 추가합니다. 이 codemod는 실험적이고 정적 사용(예: <Image src={img} layout="responsive" />)만을 다루며 동적 사용(예: <Image {...props} />)은 다루지 않습니다.
+- [next-image-experimental](/docs/pages/building-your-application/upgrading/codemods#next-image-experimental): 이전 codemod를 실행한 후, 이 실험적인 codemod를 선택적으로 실행하여 `next/legacy/image`를 새로운 `next/image`로 업그레이드할 수 있습니다. 이는 사용하지 않는 속성을 제거하고 인라인 스타일을 추가합니다. 이 codemod는 실험적이고 정적 사용(예: `<Image src={img} layout="responsive" />`)만을 다루며 동적 사용(예: `<Image {...props} />`)은 다루지 않습니다.
 
-또한, [마이그레이션 가이드]((/docs/pages/building-your-application/upgrading/codemods#next-image-experimental))를 따라 수동으로 업데이트할 수 있으며 [레거시 비교](/docs/pages/api-reference/components/image-legacy#comparison)도 참조하세요.
+또한, [마이그레이션 가이드](<(/docs/pages/building-your-application/upgrading/codemods#next-image-experimental)>)를 따라 수동으로 업데이트할 수 있으며 [레거시 비교](/docs/pages/api-reference/components/image-legacy#comparison)도 참조하세요.
 
 ### `<Link>` Component
 

--- a/pages/docs/pages/building-your-application/upgrading/version-13.mdx
+++ b/pages/docs/pages/building-your-application/upgrading/version-13.mdx
@@ -3,13 +3,11 @@ title: Version 13
 description: Upgrade your Next.js Application from Version 12 to 13.
 ---
 
-{/* TODO: 번역이 필요합니다. */}
-
 # Version 13
 
 ## Upgrading from 12 to 13
 
-To update to Next.js version 13, run the following command using your preferred package manager:
+Next.js 버전 13으로 업데이트하려면, 선호하는 패키지 매니저를 사용해 다음 명령어를 실행하세요:
 
 ```bash filename="Terminal"
 npm i next@13 react@latest react-dom@latest eslint-config-next@13
@@ -27,65 +25,66 @@ pnpm i next@13 react@latest react-dom@latest eslint-config-next@13
 bun add next@13 react@latest react-dom@latest eslint-config-next@13
 ```
 
-> **Good to know:** If you are using TypeScript, ensure you also upgrade `@types/react` and `@types/react-dom` to their latest versions.
+> **참고:** TypeScript를 사용하는 경우, `@types/react` 와 `@types/react-dom` 도 최신 버전으로 업그레이드해야 합니다.
 
 ### v13 Summary
 
-- The [Supported Browsers](/docs/architecture/supported-browsers) have been changed to drop Internet Explorer and target modern browsers.
-- The minimum Node.js version has been bumped from 12.22.0 to 16.14.0, since 12.x and 14.x have reached end-of-life.
-- The minimum React version has been bumped from 17.0.2 to 18.2.0.
-- The `swcMinify` configuration property was changed from `false` to `true`. See [Next.js Compiler](/docs/architecture/nextjs-compiler) for more info.
-- The `next/image` import was renamed to `next/legacy/image`. The `next/future/image` import was renamed to `next/image`. A [codemod is available](/docs/pages/building-your-application/upgrading/codemods#next-image-to-legacy-image) to safely and automatically rename your imports.
-- The `next/link` child can no longer be `<a>`. Add the `legacyBehavior` prop to use the legacy behavior or remove the `<a>` to upgrade. A [codemod is available](/docs/pages/building-your-application/upgrading/codemods#new-link) to automatically upgrade your code.
-- The `target` configuration property has been removed and superseded by [Output File Tracing](/docs/pages/api-reference/next-config-js/output).
+- [지원되는 브라우저](/docs/architecture/supported-browsers)가 Internet Explorer를 제외하고 최신 브라우저를 대상으로 변경되었습니다.
+- 최소 Node.js 버전이 12.22.0에서 16.14.0으로 상향되었습니다. 이는 12.x 및 14.x 버전이 지원 종료되었기 때문입니다.
+- 최소 React 버전이 17.0.2에서 18.2.0으로 상향되었습니다.
+- `swcMinify` 설정 속성이 `false`에서 `true`로 변경되었습니다. 자세한 내용은 [Next.js 컴파일러](/docs/architecture/nextjs-compiler)를 참조하세요.
+- `next/image` import가 `next/legacy/image`로, `next/future/image` import가 `next/image`로 변경되었습니다. import를 안전하게 자동으로 변경해주는 [codemod](/docs/pages/building-your-application/upgrading/codemods#next-image-to-legacy-image)가 제공됩니다.
+- `next/link`의 자식으로 `<a>` 태그를 사용할 수 없습니다. 레거시 동작을 사용하려면 `legacyBehavior prop`을 추가하거나 `<a>` 태그를 제거하여 업그레이드하세요. 코드를 자동으로 업그레이드 해주는 [codemod](/docs/pages/building-your-application/upgrading/codemods#new-link)가 제공됩니다.
+- `target` 설정 속성이 제거되고 [출력 파일 추적](/docs/pages/api-reference/next-config-js/output)으로 대체되었습니다.
 
 ## Migrating shared features
 
-Next.js 13 introduces a new [`app` directory](/docs/app/building-your-application/routing) with new features and conventions. However, upgrading to Next.js 13 does **not** require using the new [`app` directory](/docs/app/building-your-application/routing#the-app-router).
+Next.js 13은 새로운 기능과 규칙을 갖춘 [`app` 디렉토리](/docs/app/building-your-application/routing)를 도입했습니다. 그러나 Next.js 13으로 업그레이드 하기 위해 새로운 [`app` 디렉토리](/docs/app/building-your-application/routing#the-app-router)를 **반드시 사용해야 하는 것은 아닙니다.**
 
-You can continue using `pages` with new features that work in both directories, such as the updated [Image component](#image-component), [Link component](#link-component), [Script component](#script-component), and [Font optimization](#font-optimization).
+`pages`를 계속 사용할 수 있으며, 업데이트된 [Image 컴포넌트](#image-component), [Link 컴포넌트](#link-component), [Script 컴포넌트](#script-component), 및 [폰트 최적화](#font-optimization)와 같은 새 기능을 사용할 수 있습니다.
 
 ### `<Image/>` Component
 
-Next.js 12 introduced many improvements to the Image Component with a temporary import: `next/future/image`. These improvements included less client-side JavaScript, easier ways to extend and style images, better accessibility, and native browser lazy loading.
+Next.js 12는 임시 import인 `next/future/image`로 이미지 컴포넌트에 많은 개선 사항을 도입했습니다. 이러한 개선 사항에는 클라이언트 사이드 자바스크립트 감소, 이미지 확장 및 스타일링의 용이성, 더 나은 접근성, 및 브라우저의 네이티브 지연 로딩이 포함되었습니다.
 
-Starting in Next.js 13, this new behavior is now the default for `next/image`.
+Next.js 13부터 이러한 새로운 동작은 `next/image`의 기본 동작이 되었습니다.
 
-There are two codemods to help you migrate to the new Image Component:
+새로은 Image 컴포넌트로 마이그레이션하는 데 도움이 되는 두 가지 codemod가 있습니다:
 
-- [next-image-to-legacy-image](/docs/pages/building-your-application/upgrading/codemods#next-image-to-legacy-image): This codemod will safely and automatically rename `next/image` imports to `next/legacy/image` to maintain the same behavior as Next.js 12. We recommend running this codemod to quickly update to Next.js 13 automatically.
-- [next-image-experimental](/docs/pages/building-your-application/upgrading/codemods#next-image-experimental): After running the previous codemod, you can optionally run this experimental codemod to upgrade `next/legacy/image` to the new `next/image`, which will remove unused props and add inline styles. Please note this codemod is experimental and only covers static usage (such as `<Image src={img} layout="responsive" />`) but not dynamic usage (such as `<Image {...props} />`).
+- [next-image-to-legacy-image](/docs/pages/building-your-application/upgrading/codemods#next-image-to-legacy-image): 이 codemod는 `next/image` import를 `next/legacy/image`로 안전하게 자동으로 이름을 변경하여 Next.js 12와 동일한 동작을 유지합니다. Next.js 13으로 빠르게 자동으로 업데이트를 하려면 이 codemod를 실행하는 것이 좋습니다.
 
-Alternatively, you can manually update by following the [migration guide](/docs/pages/building-your-application/upgrading/codemods#next-image-experimental) and also see the [legacy comparison](/docs/pages/api-reference/components/image-legacy#comparison).
+- [next-image-experimental](/docs/pages/building-your-application/upgrading/codemods#next-image-experimental): 이전 codemod를 실행한 후, 이 실험적인 codemod를 선택적으로 실행하여 `next/legacy/image`를 새로운 `next/image`로 업그레이드할 수 있습니다. 이는 사용하지 않는 속성을 제거하고 인라인 스타일을 추가합니다. 이 codemod는 실험적이고 정적 사용(예: <Image src={img} layout="responsive" />)만을 다루며 동적 사용(예: <Image {...props} />)은 다루지 않습니다.
+
+또한, [마이그레이션 가이드]((/docs/pages/building-your-application/upgrading/codemods#next-image-experimental))를 따라 수동으로 업데이트할 수 있으며 [레거시 비교](/docs/pages/api-reference/components/image-legacy#comparison)도 참조하세요.
 
 ### `<Link>` Component
 
-The [`<Link>` Component](/docs/pages/api-reference/components/link) no longer requires manually adding an `<a>` tag as a child. This behavior was added as an experimental option in [version 12.2](https://nextjs.org/blog/next-12-2) and is now the default. In Next.js 13, `<Link>` always renders `<a>` and allows you to forward props to the underlying tag.
+[`<Link>` 컴포넌트](/docs/pages/api-reference/components/link)는 더 이상 `<a>` 태그를 수동으로 추가할 필요가 없습니다. 이 동작은 [버전 12.2](https://nextjs.org/blog/next-12-2)에서 실험적인 옵션으로 추가되었으며 이제 기본 동작이 되었습니다. Next.js 13에서는 `<Link>`가 항상 `<a>` 태그를 렌더링하고 기본 태그에 props를 전달할 수 있습니다.
 
-For example:
+예를 들어:
 
 ```jsx
 import Link from 'next/link'
 
-// Next.js 12: `<a>` has to be nested otherwise it's excluded
+// Next.js 12: `<a>` 태그가 자식 요소로 중첩되지 않으면 브라우저에서 링크로 렌더링되지 않습니다.
 <Link href="/about">
   <a>About</a>
 </Link>
 
-// Next.js 13: `<Link>` always renders `<a>` under the hood
+// Next.js 13: `<Link>`는 항상 내부적으로 `<a>` 태그를 렌더링합니다.
 <Link href="/about">
   About
 </Link>
 ```
 
-To upgrade your links to Next.js 13, you can use the [`new-link` codemod](/docs/pages/building-your-application/upgrading/codemods#new-link).
+링크를 Next.js 13으로 업그레이드하려면 [`new-link` codemod](/docs/pages/building-your-application/upgrading/codemods#new-link)를 사용할 수 있습니다.
 
 ### `<Script>` Component
 
-The behavior of [`next/script`](/docs/pages/api-reference/components/script) has been updated to support both `pages` and `app`. If incrementally adopting `app`, read the [upgrade guide](/docs/pages/building-your-application/upgrading).
+[`next/script`](/docs/pages/api-reference/components/script)의 동작은 `pages`와 `app` 모두를 지원하도록 업데이트되었습니다. `app`을 점진적으로 도입하려면 [업그레이드 가이드](/docs/pages/building-your-application/upgrading)를 읽어보세요.
 
 ### Font Optimization
 
-Previously, Next.js helped you optimize fonts by inlining font CSS. Version 13 introduces the new [`next/font`](/docs/pages/building-your-application/optimizing/fonts) module which gives you the ability to customize your font loading experience while still ensuring great performance and privacy.
+이전의 Next.js는 폰트 CSS를 인라인으로 포함하여 폰트를 최적화하는 데 도움을 주었습니다. 버전 13에서는 새 [`next/font`](/docs/pages/building-your-application/optimizing/fonts) 모듈을 도입하여 뛰어난 성능과 개인 정보 보호를 유지하면서도 폰트 로딩 경험을 사용자 맞춤으로 설정할 수 있습니다.
 
-See [Optimizing Fonts](/docs/pages/building-your-application/optimizing/fonts) to learn how to use `next/font`.
+`next/font`의 사용 방법을 알아보려면 [폰트 최적화](/docs/pages/building-your-application/optimizing/fonts)를 참조하세요.


### PR DESCRIPTION
**컨트리뷰션 체크리스트**

- [x] [기여 가이드](https://github.com/luciancah/nextjs-ko/blob/main/CONTRIBUTING.MD)를 확인한 후 작성 하셨나요?
- [x] [용어집](https://github.com/luciancah/nextjs-ko/issues/18)을 확인한 후 작성 하셨나요? 번역하신 단어 중 용어집에 추가하고싶은 단어가 있으시다면 이슈에 댓글로 남겨주세요.
- [x] title, description 등 마크다운 태그의 영문 원본 유지를 하셨나요?
- [x] 소제목 (h1~h6, ### ... 등)의 영문 유지를 하셨나요?
- [x] 문서의 전반적인 어조 톤과 일치하게 작성 하셨나요?
- [x] 코드블록 내부의 주석이나 업데이트 로그 등 표 내부의 문자도 한국어로 번역 하셨나요?


**연관된 이슈 확인**
closes #77 (신규 문서 번역), #46 (문서 내 오타 수정)

**기여 내용**

- [x] 새로운 문서 번역
- [ ] 문서 내용 수정
- [x] 오타 수정
- [ ] 문서 웹페이지 기능 수정
- [ ] 기타 기능 개선 및 수정

**문서 경로**
/docs/pages/api-reference/functions/get-server-side-props
